### PR TITLE
rpc requestOnly queue memory size limit

### DIFF
--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/info/Constants.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/info/Constants.java
@@ -221,6 +221,8 @@ public class Constants {
 
     public static final int QUEUE_SIZE = 100000;
 
+    public static final long QUEUE_MEM_LIMIT_SIZE = 180 * 1024 * 1024;
+
     /**
      * 参数类型
      * Parameter type

--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/model/RequestOnly.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/model/RequestOnly.java
@@ -1,0 +1,38 @@
+package io.nuls.core.rpc.model;
+
+import io.nuls.core.rpc.model.message.Request;
+
+/**
+ * 请求调用远程方法且不需返回
+ * Request calls to remote methods without requiring return
+ *
+ * @author tag
+ * @date 2019/09/09
+ */
+
+public class RequestOnly {
+    private Request request;
+
+    private int messageSize;
+
+    public  RequestOnly(Request request, int messageSize){
+        this.request = request;
+        this.messageSize = messageSize;
+    }
+
+    public Request getRequest() {
+        return request;
+    }
+
+    public void setRequest(Request request) {
+        this.request = request;
+    }
+
+    public int getMessageSize() {
+        return messageSize;
+    }
+
+    public void setMessageSize(int messageSize) {
+        this.messageSize = messageSize;
+    }
+}

--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/channel/ConnectData.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/channel/ConnectData.java
@@ -2,6 +2,7 @@ package io.nuls.core.rpc.netty.channel;
 
 import io.netty.channel.socket.SocketChannel;
 import io.nuls.core.rpc.info.Constants;
+import io.nuls.core.rpc.model.RequestOnly;
 import io.nuls.core.rpc.model.message.Message;
 import io.nuls.core.rpc.model.message.Request;
 import io.nuls.core.rpc.model.message.Response;
@@ -36,6 +37,12 @@ public class ConnectData {
     private boolean connected = true;
 
     /**
+     * 当前RequestOnly队列占内存大小
+     * Current memory size of RequestOnly queue
+     * */
+    private long requestOnlyQueueMemSize = 0;
+
+    /**
      * 从服务端得到的自动处理的应答消息
      * Response that need to be handled Automatically from the server
      */
@@ -45,7 +52,7 @@ public class ConnectData {
      * 客户端不需要相应的请求
      * Client does not need corresponding requests
      */
-    private final LinkedBlockingQueue<Request> requestOnlyQueue = new LinkedBlockingQueue<>(Constants.QUEUE_SIZE);
+    private final LinkedBlockingQueue<RequestOnly> requestOnlyQueue = new LinkedBlockingQueue<>(Constants.QUEUE_SIZE);
 
     /**
      * 请求超时的请求
@@ -260,8 +267,28 @@ public class ConnectData {
         return threadPool;
     }
 
-    public LinkedBlockingQueue<Request> getRequestOnlyQueue() {
+    public LinkedBlockingQueue<RequestOnly> getRequestOnlyQueue() {
         return requestOnlyQueue;
+    }
+
+    public long getRequestOnlyQueueMemSize() {
+        return requestOnlyQueueMemSize;
+    }
+
+    public void setRequestOnlyQueueMemSize(long requestOnlyQueueMemSize) {
+        this.requestOnlyQueueMemSize = requestOnlyQueueMemSize;
+    }
+
+    public boolean requestOnlyQueueReachLimit(){
+        return Constants.QUEUE_MEM_LIMIT_SIZE <= this.requestOnlyQueueMemSize;
+    }
+
+    public void addRequestOnlyQueueMemSize(long requestOnlyMemSize) {
+        this.requestOnlyQueueMemSize += requestOnlyMemSize;
+    }
+
+    public void subRequestOnlyQueueMemSize(long requestOnlyMemSize) {
+        this.requestOnlyQueueMemSize -= requestOnlyMemSize;
     }
 
     /**

--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/handler/ServerHandler.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/handler/ServerHandler.java
@@ -55,11 +55,6 @@ public class ServerHandler extends SimpleChannelInboundHandler<Object> {
             MessageType messageType = MessageType.valueOf(message.getMessageType());
             int priority = CmdPriority.DEFAULT.getPriority();
             TextMessageHandler messageHandler = new TextMessageHandler((SocketChannel) ctx.channel(), message,priority);
-            if(requestExecutorService.getQueue().size() >= 500 || responseExecutorService.getQueue().size() > 500){
-                String role = ConnectManager.getRoleByChannel(ctx.channel());
-                Log.info("链接{}当前请求线程池总线程数量{},运行中线程数量{},等待队列数量{}",role,requestExecutorService.getPoolSize(),requestExecutorService.getActiveCount(),requestExecutorService.getQueue().size());
-                Log.info("链接{}当前响应线程池总线程数量{},运行中线程数量{},等待队列数量{}",role,responseExecutorService.getPoolSize(),responseExecutorService.getActiveCount(),responseExecutorService.getQueue().size());
-            }
             if(messageType.equals(MessageType.Response)
                     || messageType.equals(MessageType.NegotiateConnectionResponse)
                     || messageType.equals(MessageType.Ack) ){
@@ -75,6 +70,10 @@ public class ServerHandler extends SimpleChannelInboundHandler<Object> {
                         }
                     }
                     messageHandler.setRequest(request);
+                }else if(messageType.equals(MessageType.RequestOnly)){
+                    Request request = JSONUtils.map2pojo((Map) message.getMessageData(), Request.class);
+                    messageHandler.setRequest(request);
+                    messageHandler.setMessageSize(bytes.length);
                 }
                 requestExecutorService.execute(messageHandler);
             }

--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/thread/RequestOnlyProcessor.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/netty/thread/RequestOnlyProcessor.java
@@ -1,5 +1,6 @@
 package io.nuls.core.rpc.netty.thread;
 import io.nuls.core.log.Log;
+import io.nuls.core.rpc.model.RequestOnly;
 import io.nuls.core.rpc.model.message.Request;
 import io.nuls.core.rpc.netty.channel.ConnectData;
 import io.nuls.core.rpc.netty.processor.RequestMessageProcessor;
@@ -30,8 +31,9 @@ public class RequestOnlyProcessor implements Runnable{
                 获取队列中的第一个对象
                 Get the first item of the queue
                  */
-                Request request = connectData.getRequestOnlyQueue().take();
-                RequestMessageProcessor.callCommands(request.getRequestMethods());
+                RequestOnly requestOnly = connectData.getRequestOnlyQueue().take();
+                connectData.subRequestOnlyQueueMemSize(requestOnly.getMessageSize());
+                RequestMessageProcessor.callCommands(requestOnly.getRequest().getRequestMethods());
             } catch (Exception e) {
                 Log.error(e);
             }


### PR DESCRIPTION
RPC requestOnly队列占内存限制为最大180M