### PR TITLE
update queue size

### DIFF
--- a/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/info/Constants.java
+++ b/common/nuls-core-rpc/src/main/java/io/nuls/core/rpc/info/Constants.java
@@ -221,7 +221,7 @@ public class Constants {
 
     public static final int QUEUE_SIZE = 100000;
 
-    public static final long QUEUE_MEM_LIMIT_SIZE = 180 * 1024 * 1024;
+    public static final long QUEUE_MEM_LIMIT_SIZE = 128 * 1024 * 1024;
 
     /**
      * 参数类型


### PR DESCRIPTION
修改rpc requestOnly 占用最大内存为128M